### PR TITLE
Cambio en configuración de Django - después del merge, revisar .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install pipenv
 ### Setup
 - On pgAdmin, open Servers, PostgreSQL 10, right click on Databases and create db with name: `db-helpo`
 - On project folder `helpo-api/`:
-  - Create file with name `.env` and text `DJANGO_SETTINGS_MODULE="helpo.settings.local"`
+  - Create file with name `.env` and text `DJANGO_SETTINGS="helpo.settings.local"`
 - Run on `helpo-api/`: 
 ```
 pipenv install --dev
@@ -47,7 +47,7 @@ npm run start
 - Install Docker.
 - From root: `docker-compose build`
 - On project folder `helpo-api/`:
-  - Create file with name `.env` and text `DJANGO_SETTINGS_MODULE="helpo.settings.docker"`
+  - Create file with name `.env` and text `DJANGO_SETTINGS="helpo.settings.docker"`
 ### Run
 - From root: `docker-compose up`
   - For using pgAdmin4 (http://localhost:5050), *Create Server*.

--- a/helpo-api/manage.py
+++ b/helpo-api/manage.py
@@ -7,7 +7,7 @@ from decouple import config
 
 
 if __name__ == "__main__":
-    settings_module = config('DJANGO_SETTINGS_MODULE', default=None)
+    settings_module = config('DJANGO_SETTINGS', default=None)
 
     if sys.argv[1] == 'test':
         if settings_module:


### PR DESCRIPTION
pipenv trabaja con variables de entorno invariables (jeje). De la forma que funcionaba antes siempre arrancaba con configuracion local y no configuracion de testing, fallando cuando se quieren correr tests unitarios.

## **Revisen nuevo contenido del archivo .env como dice en README**