### PR TITLE
Sending mail to verify account using Zoho API

### DIFF
--- a/docker-compose.aws.yml
+++ b/docker-compose.aws.yml
@@ -17,6 +17,8 @@ services:
     restart: always
     command: ["./wait-for-it.sh", "db:5432", "--", "bash", "-c", 
       "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+    env_file:
+      - helpo-api/.env
     expose:
       - "8000"
     depends_on:
@@ -24,6 +26,8 @@ services:
   web:
     image: helpo/helpo_web
     restart: always
+    env_file:
+      - helpo-web/.env
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,8 @@ services:
     restart: always
     command: ["./wait-for-it.sh", "db:5432", "--", "bash", "-c", 
       "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+    env_file:
+      - helpo-api/.env
     expose:
       - "8000"
     depends_on:
@@ -26,6 +28,8 @@ services:
       context: helpo-web/.
       dockerfile: prod.Dockerfile
     restart: always
+    env_file:
+      - helpo-web/.env
     ports:
     - "80:80"
     - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
       - db
   web:
     build: helpo-web/.
+    env_file:
+      - helpo-web/.env
     ports:
     - "3000:3000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     build: helpo-api/.
     command: ["./wait-for-it.sh", "db:5432", "--", "bash", "-c", 
       "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"]
+    env_file:
+      - helpo-api/.env
     ports:
       - "8000:8000"
     volumes:

--- a/helpo-api/helpo/settings/docker.py
+++ b/helpo-api/helpo/settings/docker.py
@@ -32,17 +32,6 @@ AUTH_PASSWORD_VALIDATORS = []  # allow easy passwords only on local
 # Celery
 CELERY_TASK_ALWAYS_EAGER = True
 
-# Email
-INSTALLED_APPS += ('naomi',)
-EMAIL_BACKEND = 'naomi.mail.backends.naomi.NaomiBackend'
-EMAIL_FILE_PATH = base_dir_join('tmp_email')
-
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_HOST_USER = config('SENDGRID_USERNAME')
-EMAIL_HOST_PASSWORD = config('SENDGRID_PASSWORD')
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-
 # django-debug-toolbar and django-debug-toolbar-request-history
 INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)

--- a/helpo-api/helpo/settings/docker.py
+++ b/helpo-api/helpo/settings/docker.py
@@ -37,6 +37,12 @@ INSTALLED_APPS += ('naomi',)
 EMAIL_BACKEND = 'naomi.mail.backends.naomi.NaomiBackend'
 EMAIL_FILE_PATH = base_dir_join('tmp_email')
 
+EMAIL_HOST = 'smtp.sendgrid.net'
+EMAIL_HOST_USER = config('SENDGRID_USERNAME')
+EMAIL_HOST_PASSWORD = config('SENDGRID_PASSWORD')
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+
 # django-debug-toolbar and django-debug-toolbar-request-history
 INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)

--- a/helpo-api/helpo/settings/production.py
+++ b/helpo-api/helpo/settings/production.py
@@ -71,19 +71,6 @@ SECURE_BROWSER_XSS_FILTER = True
 X_FRAME_OPTIONS = 'DENY'
 CSRF_COOKIE_HTTPONLY = True
 
-# Email
-INSTALLED_APPS += ('naomi',)
-EMAIL_BACKEND = 'naomi.mail.backends.naomi.NaomiBackend'
-EMAIL_FILE_PATH = base_dir_join('tmp_email')
-
-SERVER_EMAIL = 'foo@example.com'
-
-EMAIL_HOST = 'smtp.sendgrid.net'
-EMAIL_HOST_USER = config('SENDGRID_USERNAME')
-EMAIL_HOST_PASSWORD = config('SENDGRID_PASSWORD')
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-
 # django-debug-toolbar and django-debug-toolbar-request-history
 INSTALLED_APPS += ('debug_toolbar',)
 MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)

--- a/helpo-api/users/models.py
+++ b/helpo-api/users/models.py
@@ -1,10 +1,10 @@
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
 from decouple import config
 from hashlib import sha256
-from django.core.mail import send_mail
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from common.models import IndexedTimeStampedModel
+import requests
 
 class Profile(models.Model):
     usuario = models.OneToOneField('User')
@@ -75,17 +75,23 @@ class UserManager(BaseUserManager):
         uncutbash = str(sha256(str_encoded))
         bash = uncutbash[22:36]
         self.create_user_verification(user, bash)
-        """url_confirmation = '%s/confirmMail/%s' % (config('URL_CLIENT', default=None), bash)"""
-        url_confirmation = '%s/confirmMail/%s' % ('localhost:3000/#', bash)
-        content = '<a href="%s">Confirma su cuenta aquí</a>' % (url_confirmation)
-        send_mail(
-            'Confirma tu cuenta de helpo.',
-            url_confirmation,
-            'noreply@helpo.com.ar',
-            [user.email],
-            fail_silently=True,
-            html_message=content,
-        )
+
+        mail_from = "registro@helpo.com.ar"
+        subject = "Verifique su registro en Helpo"
+        url_confirmation = '%s/#/confirmMail/%s' % (config('URL_CLIENT', default='localhost:3000'), bash)
+        content = '<a href=\\"%s\\">Confirme su cuenta haciendo click aqu&iacute;</a>' % (url_confirmation)
+
+
+        url = "https://mail.zoho.com/api/accounts/%s/messages" % (config('ZOHO_ACCOUNT_ID'))
+        payload = "{\n \"fromAddress\": \"%s\",\n \"toAddress\": \"%s\",\n \"subject\": \"%s\",\n \"content\": \"%s\"\n}" \
+                    % (mail_from, user.email, subject, content)
+        headers = {
+            'Authorization': config('ZOHO_AUTH_TOKEN'),
+            'Content-Type': "application/json"
+        }
+
+        response = requests.request("POST", url, data=payload, headers=headers)
+        print("Enviando mail a %s response code: %s" % (user.email, response.status_code))
 
     def create_user_verification(self, user, token):
         UserVerification.objects.create(usuario=user, verificationToken=token)

--- a/helpo-api/users/models.py
+++ b/helpo-api/users/models.py
@@ -81,7 +81,7 @@ class UserManager(BaseUserManager):
         send_mail(
             'Confirma tu cuenta de helpo.',
             url_confirmation,
-            'helpo@helpo.com',
+            'noreply@helpo.com.ar',
             [user.email],
             fail_silently=True,
             html_message=content,


### PR DESCRIPTION
<!--- OPTIONAL -->
<!--- Provide a general summary of your changes in the Title above -->
Terminada la SP-007
## Proposed Changes
<!--- MANDATORY -->
<!--- Changes in short -->

  - No usamos más Sendgrid, lo borré de todos lados
  - Enviamos mails usando la API de Zoho, desde la cuenta registro@helpo.com.ar
  - Esto sirve para notificar cualquier cosa
  - Necesita **actualizar el .env de helpo-api**

## How Has This Been Tested?
<!--- MANDATORY -->
<!--- How you tested your changes and the results. -->
  - Lo probé local y en AWS, ahora está andando en AWS porque lo dejé puesto en la branch gulla-mail-2
  - Mandé el mail, hice click, verificó y me fijé que quedara como _confirmado_ **true** en la DB




