### PR TITLE
Adding helpo-api code autoreload using Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - .:/helpo-api/code
+      - ./helpo-api:/code
     depends_on:
       - db
   web:


### PR DESCRIPTION
<!--- OPTIONAL -->
<!--- Provide a general summary of your changes in the Title above -->
Fixing docker bind mount volume to make Django autoreload code changes from helpo-api folder
## Proposed Changes
<!--- MANDATORY -->
<!--- Changes in short -->

  - Now you can edit both **helpo-web** and **helpo-api** code and it will automatically be reloaded using docker development environment
  - Most useful 1 line PR ever