### PR TITLE
Issue/#379 - Registrar necesidades - Categoría "Otro" se convierte en alimento

### DIFF
--- a/helpo-api/actividades/management/commands/categorias_recurso.csv
+++ b/helpo-api/actividades/management/commands/categorias_recurso.csv
@@ -2,7 +2,7 @@
 Calzado,Alpargatas,Botas,Pantuflas,Ojotas,Zapatillas deportivas,Zapatillas urbanas,Zapatos,Otros
 Juguetes,Accesorios,Aire libre,Autos,Camiones,Figuras de acción,Juegos de mesa,Juegos didácticos,Juguetes de construcción,Juguetes electrónicos,Muñecas,Pelotas,Peluches,Rompecabezas,Videojuegos,Otros
 Ropa,Bufandas,Buzos,Camisas,Camperas,Cinturones,Gorros,Guantes,Pantalones,Pijamas,Poleras,Polleras,Pulóveres,Remeras,Ropa interior,Shorts,Otros
-Otros
+Otros,Otro
 Construcción,Arena,Baldes,Cemento,Mamelucos,Pinceles,Pintura,Otros
 Educación,Afiches,Carpetas,Cartulinas,Colores,Cuadernos,Fibrones,Hojas,Lapiceras,Lápices,Libros,Pizarrones,Pupitres,Tijeras,Tizas,Otros
 Animales,Alimento balanceado,Correas,Otros

--- a/helpo-web/src/views/Actividades/RegistrarNecesidades/SelectorItem/SelectorItem.js
+++ b/helpo-web/src/views/Actividades/RegistrarNecesidades/SelectorItem/SelectorItem.js
@@ -7,9 +7,13 @@ class SelectorItem extends Component {
     super(props);
     this.state = {
         categorias: [{ id: 0, nombre: 'Sin categorías' }],
-        items: [{ id: 0, nombre: 'Sin ítems', categoria: {
-          id: 0, nombre: 'Sin categorías' 
-         } }],
+        items: [{ id: 0, 
+                  nombre: 'Sin ítems', 
+                  categoria: {
+                    id: 0,
+                    nombre: 'Sin categorías' 
+                  } 
+                }],
         categoria_id: 0
       };
     this.handleChangeItem = this.handleChangeItem.bind(this); 
@@ -32,6 +36,18 @@ class SelectorItem extends Component {
     this.props.onItemChange(listaItems[0].id);
   }
 
+  firstRecursoOfCategoria(recursos, categoria_id) {
+    /*
+    Looks for first appeareance of a recurso of categoria_id, and
+    returns its id
+    */
+    for(const recurso of recursos) {
+      if (recurso.categoria.id === categoria_id) {
+        return recurso.id
+      }
+    }
+  }
+
   componentDidMount() {
     let listaCategorias, selectedCategoria;
     api.get('/actividades/categorias_recurso/')
@@ -47,7 +63,8 @@ class SelectorItem extends Component {
               categoria_id: selectedCategoria, 
               items: recursosData
             });
-            this.props.onItemChange(recursosData[0].id);
+            const selected_recurso = this.firstRecursoOfCategoria(recursosData, selectedCategoria)
+            this.props.onItemChange(selected_recurso);
           })
           .catch(function (error) {
             if (error.response){ console.log(error.response.status) }


### PR DESCRIPTION
## Proposed Changes
<!--- MANDATORY -->

  - Closes #379 
  - Se agrego recurso "Otro" a categoria "Otros", porque cada categoria tiene que tener un item
  - En SelectorItem, para agregar una necesidad de recurso, agrege una funcion que se asegura que el recurso seleccionado por default, sea valido para la categoria seleccionada por default.

## Related Issue
<!--- OPTIONAL -->
#379 
## How Has This Been Tested?
<!--- MANDATORY -->
Test exploratorio web y mobile